### PR TITLE
Add support of Debian bookworm

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 kamazee_system_bootstrap_ssh_port: 22
 deb_mirror_backports: "http://ftp.us.debian.org/debian"
+kamazee_system_bootstrap_release_codename: "{{ ansible_lsb.codename }}"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,3 +10,4 @@ galaxy_info:
     - name: Debian
       versions:
         - buster
+        - bookworm

--- a/tasks/sshd.yml
+++ b/tasks/sshd.yml
@@ -2,7 +2,7 @@
 - name: Add backports
   become: yes
   apt_repository:
-    repo: "deb {{ deb_mirror_backports }} buster-backports main"
+    repo: "deb {{ deb_mirror_backports }} {{ kamazee_system_bootstrap_release_codename }}-backports main"
 
 - name: Install latest sshd from backports
   become: yes
@@ -12,7 +12,7 @@
       - openssh-client
       - openssh-sftp-server
     state: latest
-    default_release: buster-backports
+    default_release: "{{ kamazee_system_bootstrap_release_codename }}-backports"
     update_cache: yes
     cache_valid_time: "{{ apt_cache_valid_time | default(86400) }}"
 


### PR DESCRIPTION
Not it uses the discovered distro codename by default which can be overridden (e.g. in case when the facts are not gathered)