### PR TITLE
Remove backports, add more parameters

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
 kamazee_system_bootstrap_ssh_port: 22
 deb_mirror_backports: "http://ftp.us.debian.org/debian"
-kamazee_system_bootstrap_release_codename: "{{ ansible_lsb.codename }}"
+kamazee_system_bootstrap_release_codename: "{{ ansible_distribution_release }}"
+kamazee_system_bootstrap_ssh_permit_root_login: "no"
+kamazee_system_bootstrap_ssh_password_authentication: "no"

--- a/tasks/sshd.yml
+++ b/tasks/sshd.yml
@@ -1,9 +1,4 @@
 ---
-- name: Add backports
-  become: yes
-  apt_repository:
-    repo: "deb {{ deb_mirror_backports }} {{ kamazee_system_bootstrap_release_codename }}-backports main"
-
 - name: Install latest sshd from backports
   become: yes
   apt:
@@ -12,7 +7,6 @@
       - openssh-client
       - openssh-sftp-server
     state: latest
-    default_release: "{{ kamazee_system_bootstrap_release_codename }}-backports"
     update_cache: yes
     cache_valid_time: "{{ apt_cache_valid_time | default(86400) }}"
 

--- a/templates/sshd_config
+++ b/templates/sshd_config
@@ -30,7 +30,7 @@ Port {{ kamazee_system_bootstrap_ssh_port }}
 
 #LoginGraceTime 2m
 #PermitRootLogin prohibit-password
-PermitRootLogin no
+PermitRootLogin {{ kamazee_system_bootstrap_ssh_permit_root_login }}
 #StrictModes yes
 #MaxAuthTries 6
 #MaxSessions 10
@@ -54,7 +54,7 @@ PermitRootLogin no
 #IgnoreRhosts yes
 
 # To disable tunneled clear text passwords, change to no here!
-PasswordAuthentication no
+PasswordAuthentication {{ kamazee_system_bootstrap_ssh_password_authentication }}
 #PermitEmptyPasswords no
 
 # Change to yes to enable challenge-response passwords (beware issues with
@@ -86,7 +86,7 @@ UsePAM yes
 
 AllowAgentForwarding no
 AllowTcpForwarding no
-#GatewayPorts no
+GatewayPorts no
 X11Forwarding no
 #X11DisplayOffset 10
 #X11UseLocalhost yes


### PR DESCRIPTION
Debian 13 Trixie is fairly new, so no backports are required so far. Also, local machine for testing requires root login, so corresponding sshd parameters are parametrized